### PR TITLE
Update SUSYBSM_HLT_VBF_Mu_cff.py

### DIFF
--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HLT_VBF_Mu_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_HLT_VBF_Mu_cff.py
@@ -86,6 +86,7 @@ SUSY_HLT_Mu_VBF = cms.Sequence( SUSY_HLT_Mu10_VBF +
                                 SUSY_HLT_Mu8_VBF
                                 )
 
+
 SUSY_HLT_Mu_VBF_POSTPROCESSING = cms.Sequence( SUSY_HLT_Mu10_VBF_POSTPROCESSING +
                                                SUSY_HLT_Mu8_VBF_POSTPROCESSING
                                                )


### PR DESCRIPTION
Update of the trigger of muon + VBF jets for SUSY searches.
The previous trigger was:
HLT_Mu10_TrkIsoVVL_DiPFJet40_DEta3p5_MJJ750_HTT350_PFMETNoMu60_v1 
It will remain as a backup trigger.
The new default trigger will be:
HLT_Mu8_TrkIsoVVL_DiPFJet40_DEta3p5_MJJ750_HTT300_PFMETNoMu60_v1

It requires at least one muon with pT > 8 GeV, at least one pair of jets with |delta(eta_jets)| > 3.5, pT > 40 GeV and dijet mass > 750 GeV. Also it is required MET > 60 GeV and HT > 300 GeV.
